### PR TITLE
Use object type as query response

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,11 +22,28 @@ export const builder = new SchemaBuilder<SchemaTypes>({
 
 builder.queryType({ subGraphs: ['subgraph1', 'subgraph2'] });
 
-const MyResponse = builder.objectRef<number>('MyResponse').implement({
+export interface MyType {
+  subtypes: MySubType[];
+}
+
+export interface MySubType {
+  name: string;
+}
+
+export const MySubTypeResponse = builder.objectRef<MySubType>('MySubTypeResponse').implement({
+  subGraphs: ['subgraph1'],
   fields: (t) => ({
+    name: t.exposeString("name"),
     value: t.int({
-      resolve: (value) => value,
+      resolve: (value) => 123,
     }),
+  })
+});
+
+export const MyResponse = builder.objectRef<MyType>('MyTypeResponse').implement({
+  subGraphs: ['subgraph1'],
+  fields: (t) => ({
+    subtypes: t.expose('subtypes', { type: [MySubTypeResponse], description: '' }),
   }),
 });
 
@@ -37,22 +54,26 @@ builder.queryField('someField', (t) => {
     args: {
       id: t.arg({
         type: 'ID',
+        required: true,
       }),
     },
-    resolve: (parent, { id }, context, info) => {
+    resolve: (parent, { id }, context, info): MyType => {
       //  does not work
       // @ts-expect-error
       info.cacheControl.setCacheHint({ maxAge: 123 });
 
-      // does not work either
-      // cacheControlFromInfo(info).setCacheHint({ maxAge: 123 });
-
-      return 123;
+      return {
+        subtypes: [{
+          name: 'name'
+        }]
+      }
     },
   });
 });
 
-const schema = builder.toSchema();
+const schema = builder.toSchema({
+  subGraph: ['subgraph1'],
+});
 
 const server = new ApolloServer({
   schema,


### PR DESCRIPTION
Thanks for the repro repo.

I made a small change and now my problem should be reproducible.
It occurs as soon as the query has more than one level of object types as the response.

I guess not setting `inheritMaxAge` on the child object type could be the reason.
But since the Apollo doc says this can only be set statically (https://www.apollographql.com/docs/apollo-server/performance/caching/#recommended-starting-usage) there seems to be no way to set it at all - what options do I have left to get this to work?

Edit: Ah, can be solved with the directives plugin! 

```typescript
  Directives: {
    cacheControl: {
      locations: 'FIELD_DEFINITION' | 'OBJECT' | 'INTERFACE' | 'UNION';
      args: { inheritMaxAge?: boolean; maxAge?: number; scope?: CacheScope };
    };
  };
```

Updated the issue https://github.com/hayes/pothos/issues/1059 accordingly.